### PR TITLE
add make_tracing_c with verilatortb class

### DIFF
--- a/verilator/make_tracing_c_verilatortb/Makefile
+++ b/verilator/make_tracing_c_verilatortb/Makefile
@@ -1,0 +1,101 @@
+######################################################################
+#
+# DESCRIPTION: Verilator Example: Small Makefile
+#
+# This calls the object directory makefile.  That allows the objects to
+# be placed in the "current directory" which simplifies the Makefile.
+#
+# This file ONLY is placed under the Creative Commons Public Domain, for
+# any use, without warranty, 2020 by Wilson Snyder.
+# SPDX-License-Identifier: CC0-1.0
+#
+######################################################################
+# Check for sanity to avoid later confusion
+
+ifneq ($(words $(CURDIR)),1)
+ $(error Unsupported: GNU Make cannot build in directories containing spaces, build elsewhere: '$(CURDIR)')
+endif
+
+######################################################################
+# Set up variables
+
+# If $VERILATOR_ROOT isn't in the environment, we assume it is part of a
+# package install, and verilator is in your path. Otherwise find the
+# binary relative to $VERILATOR_ROOT (such as when inside the git sources).
+ifeq ($(VERILATOR_ROOT),)
+VERILATOR = verilator
+VERILATOR_COVERAGE = verilator_coverage
+else
+export VERILATOR_ROOT
+VERILATOR = $(VERILATOR_ROOT)/bin/verilator
+VERILATOR_COVERAGE = $(VERILATOR_ROOT)/bin/verilator_coverage
+endif
+
+# Generate C++ in executable form
+VERILATOR_FLAGS += -cc --exe
+# Generate makefile dependencies (not shown as complicates the Makefile)
+#VERILATOR_FLAGS += -MMD
+# Optimize
+VERILATOR_FLAGS += -Os -x-assign 0
+# Warn abount lint issues; may not want this on less solid designs
+VERILATOR_FLAGS += -Wall
+# Make waveforms
+VERILATOR_FLAGS += --trace
+# Check SystemVerilog assertions
+VERILATOR_FLAGS += --assert
+# Generate coverage analysis
+VERILATOR_FLAGS += --coverage
+# Run Verilator in debug mode
+#VERILATOR_FLAGS += --debug
+# Add this trace to get a backtrace in gdb
+#VERILATOR_FLAGS += --gdbbt
+
+# Input files for Verilator
+VERILATOR_INPUT = -f input.vc top.v sim_main.cpp verilatortb.cpp
+
+######################################################################
+default: run
+
+run:
+	@echo
+	@echo "-- Verilator tracing example"
+
+	@echo
+	@echo "-- VERILATE ----------------"
+	$(VERILATOR) $(VERILATOR_FLAGS) $(VERILATOR_INPUT)
+
+	@echo
+	@echo "-- BUILD -------------------"
+# To compile, we can either
+# 1. Pass --build to Verilator by editing VERILATOR_FLAGS above.
+# 2. Or, run the make rules Verilator does:
+#	$(MAKE) -j -C obj_dir -f Vtop.mk
+# 3. Or, call a submakefile where we can override the rules ourselves:
+	$(MAKE) -j -C obj_dir -f ../Makefile_obj
+
+	@echo
+	@echo "-- RUN ---------------------"
+	@rm -rf logs
+	@mkdir -p logs
+	obj_dir/Vtop +trace
+
+	@echo
+	@echo "-- COVERAGE ----------------"
+	@rm -rf logs/annotated
+	$(VERILATOR_COVERAGE) --annotate logs/annotated logs/coverage.dat
+
+	@echo
+	@echo "-- DONE --------------------"
+	@echo "To see waveforms, open vlt_dump.vcd in a waveform viewer"
+	@echo
+
+
+######################################################################
+# Other targets
+
+show-config:
+	$(VERILATOR) -V
+
+maintainer-copy::
+clean mostlyclean distclean maintainer-clean::
+	-rm -rf obj_dir logs *.log *.dmp *.vpd coverage.dat core

--- a/verilator/make_tracing_c_verilatortb/Makefile_obj
+++ b/verilator/make_tracing_c_verilatortb/Makefile_obj
@@ -1,0 +1,55 @@
+# -*- Makefile -*-
+#######################################################################
+#
+# DESCRIPTION: Verilator Example: Makefile for inside object directory
+#
+# This is executed in the object directory, and called by ../Makefile
+#
+# This file ONLY is placed under the Creative Commons Public Domain, for
+# any use, without warranty, 2020 by Wilson Snyder.
+# SPDX-License-Identifier: CC0-1.0
+#
+#######################################################################
+
+default: Vtop
+
+# Include the rules made by Verilator
+include Vtop.mk
+
+# Use OBJCACHE (ccache) if using gmake and its installed
+COMPILE.cc = $(OBJCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
+
+#######################################################################
+# Compile flags
+
+# Turn on creating .d make dependency files
+CPPFLAGS += -MMD -MP
+
+# Compile in Verilator runtime debugging, so +verilator+debug works
+CPPFLAGS += -DVL_DEBUG=1
+
+# Turn on some more compiler lint flags (when configured appropriately)
+# For testing inside Verilator, "configure --enable-ccwarn" will do this
+# automatically; otherwise you may want this unconditionally enabled
+ifeq ($(CFG_WITH_CCWARN),yes)	# Local... Else don't burden users
+USER_CPPFLAGS_WALL += -W -Werror -Wall
+endif
+
+# See the benchmarking section of bin/verilator.
+# Support class optimizations.  This includes the tracing and symbol table.
+# SystemC takes minutes to optimize, thus it is off by default.
+OPT_SLOW =
+
+# Fast path optimizations.  Most time is spent in these classes.
+OPT_FAST = -Os -fstrict-aliasing
+#OPT_FAST = -O
+#OPT_FAST =
+
+######################################################################
+######################################################################
+# Automatically understand dependencies
+
+DEPS := $(wildcard *.d)
+ifneq ($(DEPS),)
+include $(DEPS)
+endif

--- a/verilator/make_tracing_c_verilatortb/input.vc
+++ b/verilator/make_tracing_c_verilatortb/input.vc
@@ -1,0 +1,2 @@
+// This file typically lists flags required by a large project, e.g. include directories
++librescan +libext+.v+.sv+.vh+.svh -y .

--- a/verilator/make_tracing_c_verilatortb/sim_main.cpp
+++ b/verilator/make_tracing_c_verilatortb/sim_main.cpp
@@ -1,0 +1,44 @@
+
+#include <memory>
+#include <verilated.h>
+
+#include "Vtop.h"
+#include "VerilatorTb.hpp"
+
+int main(int argc, char** argv, char** env) {
+
+    if (false && argc && argv && env) {}
+
+    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    contextp->commandArgs(argc, argv);
+
+    const std::unique_ptr<Vtop> top{new Vtop{contextp.get(), "TOP"}};
+    const std::unique_ptr<VerilatorTb> tb{new VerilatorTb{top.get(), contextp.get()}};
+
+
+    top->clk = 0;
+    top->reset_l = 0;
+    top->in_small = 1;
+    top->in_quad = 0x1234;
+    top->in_wide[0] = 0x11111111;
+    top->in_wide[1] = 0x22222222;
+    top->in_wide[2] = 0x3;
+
+    if(!tb->driveReset(top->clk, top->reset_l, 10)) {
+
+        while (!tb->toggleClock(top->clk,1)) {
+
+            if(!top->clk)
+	        top->in_quad += 0x12;
+
+            VL_PRINTF("[%" VL_PRI64 "d] clk=%x rstl=%x iquad=%" VL_PRI64 "x"
+                      " -> oquad=%" VL_PRI64 "x owide=%x_%08x_%08x\n",
+                      contextp->time(), top->clk, top->reset_l, top->in_quad, top->out_quad,
+                      top->out_wide[2], top->out_wide[1], top->out_wide[0]);
+        }
+    }
+
+    top->final();
+	
+    return 0;
+}

--- a/verilator/make_tracing_c_verilatortb/sub.v
+++ b/verilator/make_tracing_c_verilatortb/sub.v
@@ -1,0 +1,42 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2003 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+// ======================================================================
+
+module sub
+  (
+   input clk,
+   input reset_l
+   );
+
+   // Example counter/flop
+   reg [31:0] count_c;
+   always_ff @ (posedge clk) begin
+      if (!reset_l) begin
+         /*AUTORESET*/
+         // Beginning of autoreset for uninitialized flops
+         count_c <= 32'h0;
+         // End of automatics
+      end
+      else begin
+         count_c <= count_c + 1;
+         if (count_c >= 3) begin
+            // This write is a magic value the Makefile uses to make sure the
+            // test completes successfully.
+            $write("*-* All Finished *-*\n");
+            $finish;
+         end
+      end
+   end
+
+   // An example assertion
+   always_ff @ (posedge clk) begin
+      AssertionExample: assert (!reset_l || count_c<100);
+   end
+
+   // And example coverage analysis
+   cover property (@(posedge clk) count_c==3);
+
+endmodule

--- a/verilator/make_tracing_c_verilatortb/top.v
+++ b/verilator/make_tracing_c_verilatortb/top.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog example module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2003 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+// ======================================================================
+
+// This is intended to be a complex example of several features, please also
+// see the simpler examples/make_hello_c.
+
+module top
+  (
+   // Declare some signals so we can see how I/O works
+   input              clk,
+   input              reset_l,
+
+   output wire [1:0]  out_small,
+   output wire [39:0] out_quad,
+   output wire [69:0] out_wide,
+   input [1:0]        in_small,
+   input [39:0]       in_quad,
+   input [69:0]       in_wide
+   );
+
+   // Connect up the outputs, using some trivial logic
+   assign out_small = ~reset_l ? '0 : (in_small + 2'b1);
+   assign out_quad  = ~reset_l ? '0 : (in_quad + 40'b1);
+   assign out_wide  = ~reset_l ? '0 : (in_wide + 70'b1);
+
+   // And an example sub module. The submodule will print stuff.
+   sub sub (/*AUTOINST*/
+            // Inputs
+            .clk                        (clk),
+            .reset_l                    (reset_l));
+
+   // Print some stuff as an example
+   initial begin
+      if ($test$plusargs("trace") != 0) begin
+         $display("[%0t] Tracing to logs/vlt_dump.vcd...\n", $time);
+         $dumpfile("logs/vlt_dump.vcd");
+         $dumpvars();
+      end
+      $display("[%0t] Model running...\n", $time);
+   end
+
+endmodule

--- a/verilator/make_tracing_c_verilatortb/verilatortb.cpp
+++ b/verilator/make_tracing_c_verilatortb/verilatortb.cpp
@@ -1,0 +1,56 @@
+
+#include "verilatortb.hpp"
+
+VerilatorTb::VerilatorTb(Vtop *top_, VerilatedContext *contextp_)
+  : top(top_), contextp(contextp_)
+{
+#if VM_TRACE
+    Verilated::mkdir("logs");
+#endif
+
+    contextp->debug(0);
+    contextp->randReset(2);
+#if VM_TRACE
+    contextp->traceEverOn(true);
+#endif
+}
+
+VerilatorTb::~VerilatorTb()
+{  
+#if VM_COVERAGE
+    Verilated::mkdir("logs");
+    contextp->coveragep()->write("logs/coverage.dat");
+#endif
+}
+
+bool VerilatorTb::toggleClock(vluint8_t &clk, int cnt)
+{
+    for(int n=0 ; n<cnt ; n++){
+        clk = (clk) ? 0 : 1;
+
+	top->eval();
+
+        contextp->timeInc(1);
+
+        if(contextp->gotFinish())
+  	    return true;
+    }
+
+    return false;
+}
+
+bool VerilatorTb::driveReset(vluint8_t &clk, vluint8_t &rst_n, int count)
+{
+    rst_n = 0;
+
+    if( toggleClock(clk, count) ) {
+        return true;
+    }
+
+    
+    rst_n = 1;
+
+    return false;
+}
+
+

--- a/verilator/make_tracing_c_verilatortb/verilatortb.hpp
+++ b/verilator/make_tracing_c_verilatortb/verilatortb.hpp
@@ -1,0 +1,24 @@
+
+#ifndef VERILATORTB_HPP
+#define VERILATORTB_HPP
+
+#include "verilated.h"
+
+#include "Vtop.h"
+#include "verilatortb.hpp"
+
+class VerilatorTb {
+
+  public:
+
+    VerilatorTb(Vtop *top_, VerilatedContext *contextp_);
+    ~VerilatorTb();
+    bool toggleClock(vluint8_t &clk, int cnt);
+    bool driveReset(vluint8_t &clk, vluint8_t &rst_n, int count);
+
+  private:
+    Vtop *top;
+    VerilatedContext *contextp;
+};
+
+#endif // VERILATORTB_HPP


### PR DESCRIPTION
verilatorのexamples/make_tracing_c の sim_main.cpp の中のリセットとクロック関連を切り出した VerilatorTbクラスの追加